### PR TITLE
Add MSBuild task skeleton and failing functional tests

### DIFF
--- a/Fluidify.slnx
+++ b/Fluidify.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Fluidify/Fluidify.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Fluidify.Tests.Functional/Fluidify.Tests.Functional.csproj" />
+  </Folder>
+</Solution>

--- a/src/Fluidify/Fluidify.csproj
+++ b/src/Fluidify/Fluidify.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <PackageId>Fluidify</PackageId>
+    <Version>0.1.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)../../artifacts/pkg</PackageOutputPath>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NoWarn>NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" PrivateAssets="all" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\Fluidify.props" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="build\Fluidify.targets" Pack="true" PackagePath="build" Visible="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackTaskDlls</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="PackTaskDlls">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)**/*.dll" PackagePath="tasks/netstandard2.0" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -1,0 +1,21 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Fluidify;
+
+public class FluidifyTask : Task
+{
+    [Required]
+    public ITaskItem[] Templates { get; set; } = [];
+
+    public string OutputDir { get; set; } = "";
+
+    [Output]
+    public ITaskItem[] GeneratedFiles { get; set; } = [];
+
+    public override bool Execute()
+    {
+        // TODO: Process templates with Fluid library
+        return true;
+    }
+}

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <FluidTemplate Include="**/*.fluid" />
+    <None Include="**/*.fluid" />
+  </ItemGroup>
+
+</Project>

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -1,0 +1,19 @@
+<Project>
+
+  <UsingTask TaskName="Fluidify.FluidifyTask"
+             AssemblyFile="$(MSBuildThisFileDirectory)../tasks/netstandard2.0/Fluidify.dll" />
+
+  <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile">
+    <FluidifyTask Templates="@(FluidTemplate)"
+                  OutputDir="$(IntermediateOutputPath)Fluidify/">
+      <Output TaskParameter="GeneratedFiles" ItemName="GeneratedFluidFile" />
+    </FluidifyTask>
+
+    <!-- Add generated .cs files to compilation -->
+    <ItemGroup>
+      <Compile Include="@(GeneratedFluidFile)" Condition="'%(Extension)' == '.cs'" />
+      <Content Include="@(GeneratedFluidFile)" Condition="'%(Extension)' != '.cs'" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Config/appsettings.json.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Config/appsettings.json.fluid
@@ -1,0 +1,5 @@
+{
+  "AppName": "{{ project_name }}",
+  "Generated": {{ true }},
+  "Greeting": "{{ "hello" | capitalize }}"
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Config/appsettings.json
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Config/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "AppName": "SampleApp",
+  "Generated": true,
+  "Greeting": "Hello"
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Models/Greeting.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Models/Greeting.cs
@@ -1,0 +1,6 @@
+namespace SampleApp.Models;
+
+public static class Greeting
+{
+    public static string Message => "HELLO, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Models/Greeting.cs.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Models/Greeting.cs.fluid
@@ -1,0 +1,6 @@
+namespace SampleApp.Models;
+
+public static class Greeting
+{
+    public static string Message => "{{ "hello" | upcase }}, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fluidify" Version="0.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/nuget.config
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Local" value="../../../../artifacts/pkg" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Fluidify.Tests.Functional/Fluidify.Tests.Functional.csproj
+++ b/tests/Fluidify.Tests.Functional/Fluidify.Tests.Functional.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Fixtures/**</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fluidify.Tests.Functional/GenerationTests.cs
+++ b/tests/Fluidify.Tests.Functional/GenerationTests.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace Fluidify.Tests.Functional;
+
+[TestFixture]
+public class GenerationTests
+{
+    private static readonly string SolutionRoot = Path.GetFullPath(
+        Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+
+    private static readonly string FluidifyProject = Path.Combine(
+        SolutionRoot, "src", "Fluidify", "Fluidify.csproj");
+
+    private static readonly string SampleAppDir = Path.Combine(
+        SolutionRoot, "tests", "Fluidify.Tests.Functional", "Fixtures", "SampleApp");
+
+    private static readonly string ExpectedDir = Path.Combine(SampleAppDir, "Expected");
+
+    private static readonly string GeneratedDir = Path.Combine(
+        SampleAppDir, "obj", "Debug", "net9.0", "Fluidify");
+
+    [OneTimeSetUp]
+    public async Task PackAndBuildSampleApp()
+    {
+        // Clear any cached Fluidify package from the global NuGet cache
+        var localsResult = await RunDotnet("nuget locals global-packages --list");
+        var globalPackagesDir = localsResult.Output
+            .Replace("global-packages:", "")
+            .Replace("info :", "")
+            .Trim();
+        var fluidifyCache = Path.Combine(globalPackagesDir, "fluidify");
+        if (Directory.Exists(fluidifyCache))
+            Directory.Delete(fluidifyCache, true);
+
+        // Build Fluidify (GeneratePackageOnBuild produces the nupkg)
+        var buildResult = await RunDotnet(
+            $"build \"{FluidifyProject}\" -c Release");
+        Assert.That(buildResult.ExitCode, Is.EqualTo(0),
+            $"Fluidify build failed:\n{buildResult.Output}");
+
+        // Build SampleApp using the Fluidify NuGet
+        var sampleAppProject = Path.Combine(SampleAppDir, "SampleApp.csproj");
+        var sampleBuildResult = await RunDotnet($"build \"{sampleAppProject}\" --force");
+        Assert.That(sampleBuildResult.ExitCode, Is.EqualTo(0),
+            $"SampleApp build failed:\n{sampleBuildResult.Output}");
+    }
+
+    [TestCase("Models/Greeting.cs")]
+    [TestCase("Config/appsettings.json")]
+    public async Task FluidTemplate_GeneratesExpectedOutput(string relativePath)
+    {
+        var generatedFile = Path.Combine(GeneratedDir, relativePath);
+        var expectedFile = Path.Combine(ExpectedDir, relativePath);
+
+        Assert.That(File.Exists(generatedFile), Is.True,
+            $"Generated file not found: {generatedFile}");
+
+        var generated = await File.ReadAllTextAsync(generatedFile);
+        var expected = await File.ReadAllTextAsync(expectedFile);
+
+        Assert.That(generated, Is.EqualTo(expected),
+            $"Generated output for {relativePath} does not match expected");
+    }
+
+    private static async Task<(int ExitCode, string Output)> RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi)!;
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode, stdout + stderr);
+    }
+}


### PR DESCRIPTION
## Summary
- Add Fluidify MSBuild task project (netstandard2.0) with dummy `FluidifyTask` that will process `.fluid` Liquid templates
- Add NuGet packaging: task DLL in `tasks/`, auto-imported `.props` (registers `*.fluid` as items) and `.targets` (wires task to `CoreCompile`)
- Add NUnit functional test that builds the NuGet, consumes it from a local feed in a SampleApp fixture, and asserts generated output matches expected files
- Two test cases: `.cs.fluid` -> `.cs` and `.json.fluid` -> `.json`, both currently failing (task is a no-op)

## Test plan
- [x] `dotnet test` runs and both tests fail with "Generated file not found" (expected — task is not yet implemented)
- [x] `dotnet build src/Fluidify/Fluidify.csproj -c Release` produces a valid NuGet in `artifacts/pkg/`
- [x] NuGet contains `tasks/netstandard2.0/Fluidify.dll`, `build/Fluidify.props`, `build/Fluidify.targets`