### PR TITLE
Switch to explicit Fluidify item model with metadata params

### DIFF
--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -8,14 +8,14 @@ public class FluidifyTask : Task
     [Required]
     public ITaskItem[] Templates { get; set; } = [];
 
-    public string OutputDir { get; set; } = "";
-
-    [Output]
-    public ITaskItem[] GeneratedFiles { get; set; } = [];
-
     public override bool Execute()
     {
-        // TODO: Process templates with Fluid library
+        // TODO: For each template item:
+        // 1. Read the .fluid file (item.ItemSpec)
+        // 2. Derive output path: strip .fluid extension, or use explicit Target metadata
+        // 3. Collect all custom metadata as Liquid template variables
+        // 4. Process template with Fluid library
+        // 5. Write output file next to the template
         return true;
     }
 }

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -1,8 +1,8 @@
 <Project>
 
-  <ItemGroup>
-    <FluidTemplate Include="**/*.fluid" />
-    <None Include="**/*.fluid" />
-  </ItemGroup>
+  <!-- Define the Fluidify item type. Users add items explicitly in their csproj:
+       <Fluidify Include="**/*.fluid" />
+       <Fluidify Include="File.cs.fluid" Target="File.cs" Param1="value" />
+  -->
 
 </Project>

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -3,17 +3,9 @@
   <UsingTask TaskName="Fluidify.FluidifyTask"
              AssemblyFile="$(MSBuildThisFileDirectory)../tasks/netstandard2.0/Fluidify.dll" />
 
-  <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile">
-    <FluidifyTask Templates="@(FluidTemplate)"
-                  OutputDir="$(IntermediateOutputPath)Fluidify/">
-      <Output TaskParameter="GeneratedFiles" ItemName="GeneratedFluidFile" />
-    </FluidifyTask>
-
-    <!-- Add generated .cs files to compilation -->
-    <ItemGroup>
-      <Compile Include="@(GeneratedFluidFile)" Condition="'%(Extension)' == '.cs'" />
-      <Content Include="@(GeneratedFluidFile)" Condition="'%(Extension)' != '.cs'" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
+  <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile"
+          Condition="'@(Fluidify)' != ''">
+    <FluidifyTask Templates="@(Fluidify)" />
   </Target>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Config/appsettings.json.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Config/appsettings.json.fluid
@@ -1,5 +1,4 @@
 {
-  "AppName": "{{ project_name }}",
-  "Generated": {{ true }},
-  "Greeting": "{{ "hello" | capitalize }}"
+  "AppName": "{{ AppName }}",
+  "Version": "{{ Version }}"
 }

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Config/appsettings.json
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Config/appsettings.json
@@ -1,5 +1,4 @@
 {
   "AppName": "SampleApp",
-  "Generated": true,
-  "Greeting": "Hello"
+  "Version": "1.0.0"
 }

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Output/report.html
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Expected/Output/report.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1>Status Report</h1>
+  <p>Generated for SampleApp</p>
+</body>
+</html>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Models/Greeting.cs.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Models/Greeting.cs.fluid
@@ -2,5 +2,5 @@ namespace SampleApp.Models;
 
 public static class Greeting
 {
-    public static string Message => "{{ "hello" | upcase }}, World!";
+    public static string Message => "{{ Greeting }}, World!";
 }

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -9,4 +9,9 @@
     <PackageReference Include="Fluidify" Version="0.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
+    <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
     <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
+    <Fluidify Include="Templates/report.html.fluid" Target="Output/report.html" Title="Status Report" Author="SampleApp" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Templates/report.html.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/Templates/report.html.fluid
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1>{{ Title }}</h1>
+  <p>Generated for {{ Author }}</p>
+</body>
+</html>

--- a/tests/Fluidify.Tests.Functional/GenerationTests.cs
+++ b/tests/Fluidify.Tests.Functional/GenerationTests.cs
@@ -45,6 +45,7 @@ public class GenerationTests
 
     [TestCase("Models/Greeting.cs")]
     [TestCase("Config/appsettings.json")]
+    [TestCase("Output/report.html")]
     public async Task FluidTemplate_GeneratesExpectedOutput(string relativePath)
     {
         var generatedFile = Path.Combine(SampleAppDir, relativePath);

--- a/tests/Fluidify.Tests.Functional/GenerationTests.cs
+++ b/tests/Fluidify.Tests.Functional/GenerationTests.cs
@@ -17,9 +17,6 @@ public class GenerationTests
 
     private static readonly string ExpectedDir = Path.Combine(SampleAppDir, "Expected");
 
-    private static readonly string GeneratedDir = Path.Combine(
-        SampleAppDir, "obj", "Debug", "net9.0", "Fluidify");
-
     [OneTimeSetUp]
     public async Task PackAndBuildSampleApp()
     {
@@ -50,7 +47,7 @@ public class GenerationTests
     [TestCase("Config/appsettings.json")]
     public async Task FluidTemplate_GeneratesExpectedOutput(string relativePath)
     {
-        var generatedFile = Path.Combine(GeneratedDir, relativePath);
+        var generatedFile = Path.Combine(SampleAppDir, relativePath);
         var expectedFile = Path.Combine(ExpectedDir, relativePath);
 
         Assert.That(File.Exists(generatedFile), Is.True,


### PR DESCRIPTION
## Summary
- Replace auto-discovery glob with explicit `<Fluidify>` items in consumer csproj
- Support custom metadata as Liquid template variables (e.g., `<Fluidify Include="File.cs.fluid" Greeting="HELLO" />`)
- Generated files output next to templates (T4-style) instead of in `obj/`
- Templates now use metadata params (`{{ Greeting }}`, `{{ AppName }}`) instead of hardcoded Liquid filters

## Example usage
```xml
<ItemGroup>
  <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
  <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
</ItemGroup>
```

## Test plan
- [x] `dotnet test` runs and both tests fail with "Generated file not found" (expected — task is not yet implemented)
- [x] `dotnet build src/Fluidify/Fluidify.csproj -c Release` produces a valid NuGet in `artifacts/pkg/`