### PR TITLE
Implement Fluid template processing

### DIFF
--- a/src/Fluidify/Fluidify.csproj
+++ b/src/Fluidify/Fluidify.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build\Fluidify.props" Pack="true" PackagePath="build" Visible="false" />
     <None Include="build\Fluidify.targets" Pack="true" PackagePath="build" Visible="false" />
   </ItemGroup>
 

--- a/src/Fluidify/Fluidify.csproj
+++ b/src/Fluidify/Fluidify.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Fluid.Core" Version="2.31.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -17,45 +17,45 @@ public class FluidifyTask : Task
 
     public override bool Execute()
     {
-        var parser = new FluidParser();
+        FluidParser parser = new FluidParser();
 
-        foreach (var item in Templates)
+        foreach (ITaskItem item in Templates)
         {
-            var templatePath = item.GetMetadata("FullPath");
-            var templateContent = File.ReadAllText(templatePath);
+            string templatePath = item.GetMetadata("FullPath");
+            string templateContent = File.ReadAllText(templatePath);
 
-            if (!parser.TryParse(templateContent, out var template, out var error))
+            if (!parser.TryParse(templateContent, out IFluidTemplate template, out string error))
             {
                 Log.LogError("Failed to parse template '{0}': {1}", templatePath, error);
                 return false;
             }
 
-            var target = item.GetMetadata("Destination");
+            string destination = item.GetMetadata("Destination");
             string outputPath;
-            if (!string.IsNullOrEmpty(target))
+            if (!string.IsNullOrEmpty(destination))
             {
-                outputPath = Path.IsPathRooted(target)
-                    ? target
-                    : Path.Combine(ProjectDirectory, target);
+                outputPath = Path.IsPathRooted(destination)
+                    ? destination
+                    : Path.Combine(ProjectDirectory, destination);
             }
             else
             {
                 outputPath = templatePath.Substring(0, templatePath.Length - ".fluid".Length);
             }
 
-            var context = new TemplateContext();
+            TemplateContext context = new TemplateContext();
             foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
-                var key = entry.Key.ToString();
+                string key = entry.Key.ToString();
                 if (!string.Equals(key, "Destination", StringComparison.OrdinalIgnoreCase))
                 {
                     context.SetValue(key, entry.Value?.ToString() ?? "");
                 }
             }
 
-            var result = template.Render(context);
+            string result = template.Render(context);
 
-            var outputDir = Path.GetDirectoryName(outputPath);
+            string outputDir = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(outputDir))
                 Directory.CreateDirectory(outputDir);
 

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -30,7 +30,7 @@ public class FluidifyTask : Task
                 return false;
             }
 
-            var target = item.GetMetadata("OutputPath");
+            var target = item.GetMetadata("Destination");
             string outputPath;
             if (!string.IsNullOrEmpty(target))
             {
@@ -47,7 +47,7 @@ public class FluidifyTask : Task
             foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
                 var key = entry.Key.ToString();
-                if (!string.Equals(key, "OutputPath", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(key, "Destination", StringComparison.OrdinalIgnoreCase))
                 {
                     context.SetValue(key, entry.Value?.ToString() ?? "");
                 }

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections;
 using System.IO;
 using Fluid;
 using Microsoft.Build.Framework;
@@ -9,17 +9,6 @@ namespace Fluidify;
 
 public class FluidifyTask : Task
 {
-    private static readonly HashSet<string> ExcludedMetadata = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-    {
-        "FullPath", "RootDir", "Filename", "Extension", "RelativeDir",
-        "Directory", "RecursiveDir", "Identity", "ModifiedTime",
-        "CreatedTime", "AccessedTime", "DefiningProjectFullPath",
-        "DefiningProjectDirectory", "DefiningProjectName",
-        "DefiningProjectExtension", "MSBuildSourceProjectFile",
-        "MSBuildSourceTargetName", "OriginalItemSpec",
-        "TargetPath"
-    };
-
     [Required]
     public ITaskItem[] Templates { get; set; } = Array.Empty<ITaskItem>();
 
@@ -55,12 +44,12 @@ public class FluidifyTask : Task
             }
 
             var context = new TemplateContext();
-            foreach (var name in item.MetadataNames)
+            foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
-                var metadataName = name.ToString();
-                if (!ExcludedMetadata.Contains(metadataName))
+                var key = entry.Key.ToString();
+                if (!string.Equals(key, "TargetPath", StringComparison.OrdinalIgnoreCase))
                 {
-                    context.SetValue(metadataName, item.GetMetadata(metadataName));
+                    context.SetValue(key, entry.Value?.ToString() ?? "");
                 }
             }
 

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -30,7 +30,7 @@ public class FluidifyTask : Task
                 return false;
             }
 
-            var target = item.GetMetadata("TargetPath");
+            var target = item.GetMetadata("OutputPath");
             string outputPath;
             if (!string.IsNullOrEmpty(target))
             {
@@ -47,7 +47,7 @@ public class FluidifyTask : Task
             foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
                 var key = entry.Key.ToString();
-                if (!string.Equals(key, "TargetPath", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(key, "OutputPath", StringComparison.OrdinalIgnoreCase))
                 {
                     context.SetValue(key, entry.Value?.ToString() ?? "");
                 }

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Fluid;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -5,17 +9,71 @@ namespace Fluidify;
 
 public class FluidifyTask : Task
 {
+    private static readonly HashSet<string> ExcludedMetadata = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "FullPath", "RootDir", "Filename", "Extension", "RelativeDir",
+        "Directory", "RecursiveDir", "Identity", "ModifiedTime",
+        "CreatedTime", "AccessedTime", "DefiningProjectFullPath",
+        "DefiningProjectDirectory", "DefiningProjectName",
+        "DefiningProjectExtension", "MSBuildSourceProjectFile",
+        "MSBuildSourceTargetName", "OriginalItemSpec",
+        "TargetPath"
+    };
+
     [Required]
-    public ITaskItem[] Templates { get; set; } = [];
+    public ITaskItem[] Templates { get; set; } = Array.Empty<ITaskItem>();
+
+    [Required]
+    public string ProjectDirectory { get; set; } = "";
 
     public override bool Execute()
     {
-        // TODO: For each template item:
-        // 1. Read the .fluid file (item.ItemSpec)
-        // 2. Derive output path: strip .fluid extension, or use explicit Target metadata
-        // 3. Collect all custom metadata as Liquid template variables
-        // 4. Process template with Fluid library
-        // 5. Write output file next to the template
+        var parser = new FluidParser();
+
+        foreach (var item in Templates)
+        {
+            var templatePath = item.GetMetadata("FullPath");
+            var templateContent = File.ReadAllText(templatePath);
+
+            if (!parser.TryParse(templateContent, out var template, out var error))
+            {
+                Log.LogError("Failed to parse template '{0}': {1}", templatePath, error);
+                return false;
+            }
+
+            var target = item.GetMetadata("TargetPath");
+            string outputPath;
+            if (!string.IsNullOrEmpty(target))
+            {
+                outputPath = Path.IsPathRooted(target)
+                    ? target
+                    : Path.Combine(ProjectDirectory, target);
+            }
+            else
+            {
+                outputPath = templatePath.Substring(0, templatePath.Length - ".fluid".Length);
+            }
+
+            var context = new TemplateContext();
+            foreach (var name in item.MetadataNames)
+            {
+                var metadataName = name.ToString();
+                if (!ExcludedMetadata.Contains(metadataName))
+                {
+                    context.SetValue(metadataName, item.GetMetadata(metadataName));
+                }
+            }
+
+            var result = template.Render(context);
+
+            var outputDir = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(outputDir))
+                Directory.CreateDirectory(outputDir);
+
+            File.WriteAllText(outputPath, result);
+            Log.LogMessage(MessageImportance.Normal, "Fluidify: {0} -> {1}", item.ItemSpec, outputPath);
+        }
+
         return true;
     }
 }

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -1,8 +1,0 @@
-<Project>
-
-  <!-- Define the Fluidify item type. Users add items explicitly in their csproj:
-       <Fluidify Include="**/*.fluid" />
-       <Fluidify Include="File.cs.fluid" Destination="File.cs" Param1="value" />
-  -->
-
-</Project>

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -2,7 +2,7 @@
 
   <!-- Define the Fluidify item type. Users add items explicitly in their csproj:
        <Fluidify Include="**/*.fluid" />
-       <Fluidify Include="File.cs.fluid" Target="File.cs" Param1="value" />
+       <Fluidify Include="File.cs.fluid" TargetPath="File.cs" Param1="value" />
   -->
 
 </Project>

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -2,7 +2,7 @@
 
   <!-- Define the Fluidify item type. Users add items explicitly in their csproj:
        <Fluidify Include="**/*.fluid" />
-       <Fluidify Include="File.cs.fluid" OutputPath="File.cs" Param1="value" />
+       <Fluidify Include="File.cs.fluid" Destination="File.cs" Param1="value" />
   -->
 
 </Project>

--- a/src/Fluidify/build/Fluidify.props
+++ b/src/Fluidify/build/Fluidify.props
@@ -2,7 +2,7 @@
 
   <!-- Define the Fluidify item type. Users add items explicitly in their csproj:
        <Fluidify Include="**/*.fluid" />
-       <Fluidify Include="File.cs.fluid" TargetPath="File.cs" Param1="value" />
+       <Fluidify Include="File.cs.fluid" OutputPath="File.cs" Param1="value" />
   -->
 
 </Project>

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -5,7 +5,7 @@
 
   <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile"
           Condition="'@(Fluidify)' != ''">
-    <FluidifyTask Templates="@(Fluidify)" />
+    <FluidifyTask Templates="@(Fluidify)" ProjectDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
     <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
-    <Fluidify Include="Templates/report.html.fluid" Target="Output/report.html" Title="Status Report" Author="SampleApp" />
+    <Fluidify Include="Templates/report.html.fluid" TargetPath="Output/report.html" Title="Status Report" Author="SampleApp" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <!-- Exclude expected test output files from compilation to prevent duplicate type definitions (e.g. CS0101) -->
     <DefaultItemExcludes>$(DefaultItemExcludes);Expected/**</DefaultItemExcludes>
   </PropertyGroup>
 
@@ -13,7 +14,7 @@
   <ItemGroup>
     <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
     <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
-    <Fluidify Include="Templates/report.html.fluid" TargetPath="Output/report.html" Title="Status Report" Author="SampleApp" />
+    <Fluidify Include="Templates/report.html.fluid" OutputPath="Output/report.html" Title="Status Report" Author="SampleApp" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
     <Fluidify Include="Config/appsettings.json.fluid" AppName="SampleApp" Version="1.0.0" />
-    <Fluidify Include="Templates/report.html.fluid" OutputPath="Output/report.html" Title="Status Report" Author="SampleApp" />
+    <Fluidify Include="Templates/report.html.fluid" Destination="Output/report.html" Title="Status Report" Author="SampleApp" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Expected/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Fluidify.Tests.Functional/GenerationTests.cs
+++ b/tests/Fluidify.Tests.Functional/GenerationTests.cs
@@ -17,9 +17,20 @@ public class GenerationTests
 
     private static readonly string ExpectedDir = Path.Combine(SampleAppDir, "Expected");
 
+    private static readonly string[] GeneratedPaths =
+        ["Models/Greeting.cs", "Config/appsettings.json", "Output/report.html"];
+
     [OneTimeSetUp]
     public async Task PackAndBuildSampleApp()
     {
+        // Clean previously generated output files to avoid stale artifacts
+        foreach (var path in GeneratedPaths)
+        {
+            var fullPath = Path.Combine(SampleAppDir, path);
+            if (File.Exists(fullPath))
+                File.Delete(fullPath);
+        }
+
         // Clear any cached Fluidify package from the global NuGet cache
         var localsResult = await RunDotnet("nuget locals global-packages --list");
         var globalPackagesDir = localsResult.Output

--- a/tests/Fluidify.Tests.Functional/GenerationTests.cs
+++ b/tests/Fluidify.Tests.Functional/GenerationTests.cs
@@ -24,32 +24,32 @@ public class GenerationTests
     public async Task PackAndBuildSampleApp()
     {
         // Clean previously generated output files to avoid stale artifacts
-        foreach (var path in GeneratedPaths)
+        foreach (string path in GeneratedPaths)
         {
-            var fullPath = Path.Combine(SampleAppDir, path);
+            string fullPath = Path.Combine(SampleAppDir, path);
             if (File.Exists(fullPath))
                 File.Delete(fullPath);
         }
 
         // Clear any cached Fluidify package from the global NuGet cache
-        var localsResult = await RunDotnet("nuget locals global-packages --list");
-        var globalPackagesDir = localsResult.Output
+        (int ExitCode, string Output) localsResult = await RunDotnet("nuget locals global-packages --list");
+        string globalPackagesDir = localsResult.Output
             .Replace("global-packages:", "")
             .Replace("info :", "")
             .Trim();
-        var fluidifyCache = Path.Combine(globalPackagesDir, "fluidify");
+        string fluidifyCache = Path.Combine(globalPackagesDir, "fluidify");
         if (Directory.Exists(fluidifyCache))
             Directory.Delete(fluidifyCache, true);
 
         // Build Fluidify (GeneratePackageOnBuild produces the nupkg)
-        var buildResult = await RunDotnet(
+        (int ExitCode, string Output) buildResult = await RunDotnet(
             $"build \"{FluidifyProject}\" -c Release");
         Assert.That(buildResult.ExitCode, Is.EqualTo(0),
             $"Fluidify build failed:\n{buildResult.Output}");
 
         // Build SampleApp using the Fluidify NuGet
-        var sampleAppProject = Path.Combine(SampleAppDir, "SampleApp.csproj");
-        var sampleBuildResult = await RunDotnet($"build \"{sampleAppProject}\" --force");
+        string sampleAppProject = Path.Combine(SampleAppDir, "SampleApp.csproj");
+        (int ExitCode, string Output) sampleBuildResult = await RunDotnet($"build \"{sampleAppProject}\" --force");
         Assert.That(sampleBuildResult.ExitCode, Is.EqualTo(0),
             $"SampleApp build failed:\n{sampleBuildResult.Output}");
     }
@@ -59,14 +59,14 @@ public class GenerationTests
     [TestCase("Output/report.html")]
     public async Task FluidTemplate_GeneratesExpectedOutput(string relativePath)
     {
-        var generatedFile = Path.Combine(SampleAppDir, relativePath);
-        var expectedFile = Path.Combine(ExpectedDir, relativePath);
+        string generatedFile = Path.Combine(SampleAppDir, relativePath);
+        string expectedFile = Path.Combine(ExpectedDir, relativePath);
 
         Assert.That(File.Exists(generatedFile), Is.True,
             $"Generated file not found: {generatedFile}");
 
-        var generated = await File.ReadAllTextAsync(generatedFile);
-        var expected = await File.ReadAllTextAsync(expectedFile);
+        string generated = await File.ReadAllTextAsync(generatedFile);
+        string expected = await File.ReadAllTextAsync(expectedFile);
 
         Assert.That(generated, Is.EqualTo(expected),
             $"Generated output for {relativePath} does not match expected");
@@ -74,16 +74,16 @@ public class GenerationTests
 
     private static async Task<(int ExitCode, string Output)> RunDotnet(string arguments)
     {
-        var psi = new ProcessStartInfo("dotnet", arguments)
+        ProcessStartInfo psi = new ProcessStartInfo("dotnet", arguments)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
         };
 
-        using var process = Process.Start(psi)!;
-        var stdout = await process.StandardOutput.ReadToEndAsync();
-        var stderr = await process.StandardError.ReadToEndAsync();
+        using Process process = Process.Start(psi)!;
+        string stdout = await process.StandardOutput.ReadToEndAsync();
+        string stderr = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
 
         return (process.ExitCode, stdout + stderr);


### PR DESCRIPTION
## Summary
- Implement `FluidifyTask.Execute()` using the Fluid library to parse and render Liquid templates
- Add `Fluid.Core` 2.31.0 as a dependency, pass custom item metadata as Liquid template variables
- Rename `Target` metadata to `TargetPath` since `Target` is a reserved MSBuild attribute
- Pass `ProjectDirectory` from targets to resolve relative `TargetPath` values

## Test plan
- [x] All 3 functional tests pass (Models/Greeting.cs, Config/appsettings.json, Output/report.html)