### PR TITLE
Support incremental builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Fluidify registers an MSBuild target that runs before `CoreCompile`. For each `<
 2. Passes all item metadata (except `Destination`) as template variables
 3. Writes the rendered output to the inferred or specified destination
 
+MSBuild tracks input and output timestamps, so templates are only re-rendered when the source file changes.
+
 ## License
 
 Apache-2.0

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -3,8 +3,26 @@
   <UsingTask TaskName="Fluidify.FluidifyTask"
              AssemblyFile="$(MSBuildThisFileDirectory)../tasks/netstandard2.0/Fluidify.dll" />
 
-  <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile"
+  <Target Name="ComputeFluidifyOutputs"
           Condition="'@(Fluidify)' != ''">
+    <ItemGroup>
+      <Fluidify Condition="'%(Fluidify.Destination)' == ''">
+        <OutputPath>%(RootDir)%(Directory)%(Filename)</OutputPath>
+      </Fluidify>
+      <Fluidify Condition="'%(Fluidify.Destination)' != '' and $([System.IO.Path]::IsPathRooted('%(Fluidify.Destination)'))">
+        <OutputPath>%(Fluidify.Destination)</OutputPath>
+      </Fluidify>
+      <Fluidify Condition="'%(Fluidify.Destination)' != '' and !$([System.IO.Path]::IsPathRooted('%(Fluidify.Destination)'))">
+        <OutputPath>$(MSBuildProjectDirectory)\%(Fluidify.Destination)</OutputPath>
+      </Fluidify>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ProcessFluidTemplates" BeforeTargets="CoreCompile"
+          DependsOnTargets="ComputeFluidifyOutputs"
+          Condition="'@(Fluidify)' != ''"
+          Inputs="@(Fluidify)"
+          Outputs="@(Fluidify -> '%(OutputPath)')">
     <FluidifyTask Templates="@(Fluidify)" ProjectDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 


### PR DESCRIPTION
## Summary
- Add `Inputs`/`Outputs` to the `ProcessFluidTemplates` MSBuild target so templates are only re-rendered when source files change
- A `ComputeFluidifyOutputs` target resolves the output path for each `<Fluidify>` item (inferred from filename or explicit `Destination`)
- Mention incremental build behavior in README

## Test plan
- [x] All existing functional tests pass
- [x] First build processes all templates (`Building target "ProcessFluidTemplates" completely.`)
- [x] Second build with no changes skips the target (`Skipping target "ProcessFluidTemplates" because all output files are up-to-date`)