### PR TITLE
Auto-include generated .cs files in compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ Building the project renders each template before compilation. The output path i
 
 Fluidify works with any text format — C#, JSON, HTML, YAML, or anything else. The `.fluid` extension is just a convention; the template itself is plain text with Liquid tags.
 
-### Including generated C# in compilation
+### Compilation
 
-By default, generated `.cs` files are not automatically compiled — MSBuild's SDK glob evaluates before templates are rendered. Add `Compile="true"` to include the output in compilation:
+Generated `.cs` files are automatically included in compilation. To opt out, set `Compile="false"`:
 
 ```xml
 <ItemGroup>
-  <Fluidify Include="WelcomeMessage.cs.fluid" Name="Alice" Compile="true" />
+  <Fluidify Include="WelcomeMessage.cs.fluid" Name="Alice" Compile="false" />
+</ItemGroup>
+```
+
+For non-`.cs` outputs that should be compiled, set `Compile="true"` explicitly:
+
+```xml
+<ItemGroup>
+  <Fluidify Include="Templates/Helper.fluid" Compile="true" />
 </ItemGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,34 @@ Add `<Fluidify>` items to your project file. Each item points to a `.fluid` temp
 
 ```xml
 <ItemGroup>
-  <Fluidify Include="Models/Greeting.cs.fluid" Greeting="HELLO" />
+  <Fluidify Include="WelcomeMessage.cs.fluid" Name="Alice" />
   <Fluidify Include="Config/appsettings.json.fluid" AppName="MyApp" Version="1.0.0" />
 </ItemGroup>
 ```
 
 Templates use standard [Liquid syntax](https://shopify.github.io/liquid/):
 
-**Models/Greeting.cs.fluid**
+**WelcomeMessage.cs.fluid**
 ```liquid
-public static class Greeting
+public static class WelcomeMessage
 {
-    public const string Value = "{{ Greeting }}, World!";
+    public const string Text = "Welcome, {{ Name }}!";
 }
 ```
 
-Building the project renders each template before compilation. The output path is inferred by stripping the `.fluid` extension, so `Models/Greeting.cs.fluid` produces `Models/Greeting.cs`.
+Building the project renders each template before compilation. The output path is inferred by stripping the `.fluid` extension, so `WelcomeMessage.cs.fluid` produces `WelcomeMessage.cs`.
 
 Fluidify works with any text format — C#, JSON, HTML, YAML, or anything else. The `.fluid` extension is just a convention; the template itself is plain text with Liquid tags.
+
+### Including generated C# in compilation
+
+By default, generated `.cs` files are not automatically compiled — MSBuild's SDK glob evaluates before templates are rendered. Add `Compile="true"` to include the output in compilation:
+
+```xml
+<ItemGroup>
+  <Fluidify Include="WelcomeMessage.cs.fluid" Name="Alice" Compile="true" />
+</ItemGroup>
+```
 
 ### Custom output path
 
@@ -55,7 +65,7 @@ Relative paths are resolved from the project directory. Directories are created 
 Fluidify registers an MSBuild target that runs before `CoreCompile`. For each `<Fluidify>` item it:
 
 1. Parses the `.fluid` file using the Fluid template engine
-2. Passes all item metadata (except `Destination`) as template variables
+2. Passes all item metadata (except `Destination` and `Compile`) as template variables
 3. Writes the rendered output to the inferred or specified destination
 
 MSBuild tracks input and output timestamps, so templates are only re-rendered when the source file changes.

--- a/src/Fluidify/Fluidify.csproj
+++ b/src/Fluidify/Fluidify.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Fluidify</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.0.0-local</Version>
     <Authors>stanoddly</Authors>
     <Description>A modern alternative to T4 — an MSBuild task that processes Fluid (Liquid) template files at build time to generate code, configuration, or any other text output.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -47,7 +47,8 @@ public class FluidifyTask : Task
             foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
                 string key = entry.Key.ToString();
-                if (!string.Equals(key, "Destination", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(key, "Destination", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(key, "Compile", StringComparison.OrdinalIgnoreCase))
                 {
                     context.SetValue(key, entry.Value?.ToString() ?? "");
                 }

--- a/src/Fluidify/FluidifyTask.cs
+++ b/src/Fluidify/FluidifyTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Fluid;
 using Microsoft.Build.Framework;
@@ -9,6 +10,9 @@ namespace Fluidify;
 
 public class FluidifyTask : Task
 {
+    private static readonly HashSet<string> ExcludedMetadataKeys =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Destination", "Compile" };
+
     [Required]
     public ITaskItem[] Templates { get; set; } = Array.Empty<ITaskItem>();
 
@@ -47,8 +51,7 @@ public class FluidifyTask : Task
             foreach (DictionaryEntry entry in item.CloneCustomMetadata())
             {
                 string key = entry.Key.ToString();
-                if (!string.Equals(key, "Destination", StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(key, "Compile", StringComparison.OrdinalIgnoreCase))
+                if (!ExcludedMetadataKeys.Contains(key))
                 {
                     context.SetValue(key, entry.Value?.ToString() ?? "");
                 }

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -30,7 +30,9 @@
           DependsOnTargets="ProcessFluidTemplates"
           Condition="'@(Fluidify)' != ''">
     <ItemGroup>
-      <!-- Auto-include .cs outputs unless Compile="false"; also honor explicit Compile="true" for any extension -->
+      <!-- Auto-include .cs outputs unless Compile="false"; also honor explicit Compile="true" for any extension.
+           Remove then Include: prevents duplicate Compile entries when the file already exists on disk
+           from a previous build and was picked up by the SDK glob at project load time. -->
       <Compile Remove="%(Fluidify.OutputPath)"
                Condition="('%(Fluidify.Compile)' == 'true') or
                           ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -30,15 +30,17 @@
           DependsOnTargets="ProcessFluidTemplates"
           Condition="'@(Fluidify)' != ''">
     <ItemGroup>
-      <!-- Auto-include .cs outputs unless Compile="false"; also honor explicit Compile="true" for any extension.
-           Remove then Include: prevents duplicate Compile entries when the file already exists on disk
+      <!-- Collect outputs that should be compiled: .cs by default (unless Compile="false"), others only with Compile="true". -->
+      <_FluidifyCompileOutput Include="%(Fluidify.OutputPath)"
+                              Condition="('%(Fluidify.Compile)' == 'true') or
+                                         ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Remove then Include: prevents duplicate Compile entries when the file already exists on disk
            from a previous build and was picked up by the SDK glob at project load time. -->
-      <Compile Remove="%(Fluidify.OutputPath)"
-               Condition="('%(Fluidify.Compile)' == 'true') or
-                          ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />
-      <Compile Include="%(Fluidify.OutputPath)"
-               Condition="('%(Fluidify.Compile)' == 'true') or
-                          ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />
+      <Compile Remove="@(_FluidifyCompileOutput)" />
+      <Compile Include="@(_FluidifyCompileOutput)" />
+      <_FluidifyCompileOutput Remove="@(_FluidifyCompileOutput)" />
     </ItemGroup>
   </Target>
 

--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -26,4 +26,18 @@
     <FluidifyTask Templates="@(Fluidify)" ProjectDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
+  <Target Name="AddFluidifyCompileItems" BeforeTargets="CoreCompile"
+          DependsOnTargets="ProcessFluidTemplates"
+          Condition="'@(Fluidify)' != ''">
+    <ItemGroup>
+      <!-- Auto-include .cs outputs unless Compile="false"; also honor explicit Compile="true" for any extension -->
+      <Compile Remove="%(Fluidify.OutputPath)"
+               Condition="('%(Fluidify.Compile)' == 'true') or
+                          ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />
+      <Compile Include="%(Fluidify.OutputPath)"
+               Condition="('%(Fluidify.Compile)' == 'true') or
+                          ($([System.IO.Path]::GetExtension('%(Fluidify.OutputPath)')) == '.cs' and '%(Fluidify.Compile)' != 'false')" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/tests/Fluidify.Tests.Functional/CompileTests.cs
+++ b/tests/Fluidify.Tests.Functional/CompileTests.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace Fluidify.Tests.Functional;
+
+[TestFixture]
+public class CompileTests
+{
+    private static readonly string SolutionRoot = Path.GetFullPath(
+        Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+
+    private static readonly string FluidifyProject = Path.Combine(
+        SolutionRoot, "src", "Fluidify", "Fluidify.csproj");
+
+    private static readonly string CompileAppDir = Path.Combine(
+        SolutionRoot, "tests", "Fluidify.Tests.Functional", "Fixtures", "CompileApp");
+
+    [OneTimeSetUp]
+    public async Task PackAndBuildFluidify()
+    {
+        // Clear any cached Fluidify package from the global NuGet cache
+        (int ExitCode, string Output) localsResult = await RunDotnet("nuget locals global-packages --list");
+        string globalPackagesDir = localsResult.Output
+            .Replace("global-packages:", "")
+            .Replace("info :", "")
+            .Trim();
+        string fluidifyCache = Path.Combine(globalPackagesDir, "fluidify");
+        if (Directory.Exists(fluidifyCache))
+            Directory.Delete(fluidifyCache, true);
+
+        // Build Fluidify (GeneratePackageOnBuild produces the nupkg)
+        (int ExitCode, string Output) buildResult = await RunDotnet(
+            $"build \"{FluidifyProject}\" -c Release");
+        Assert.That(buildResult.ExitCode, Is.EqualTo(0),
+            $"Fluidify build failed:\n{buildResult.Output}");
+    }
+
+    [Test]
+    public async Task GeneratedCsFile_IsCompiledSuccessfully()
+    {
+        string generatedFile = Path.Combine(CompileAppDir, "Models", "Greeter.cs");
+
+        // Delete generated file to simulate a clean build
+        if (File.Exists(generatedFile))
+            File.Delete(generatedFile);
+
+        string compileAppProject = Path.Combine(CompileAppDir, "CompileApp.csproj");
+        (int ExitCode, string Output) result = await RunDotnet($"build \"{compileAppProject}\" --force");
+
+        Assert.That(result.ExitCode, Is.EqualTo(0),
+            $"CompileApp build failed — generated .cs file was not included in compilation:\n{result.Output}");
+    }
+
+    private static async Task<(int ExitCode, string Output)> RunDotnet(string arguments)
+    {
+        ProcessStartInfo psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi)!;
+        string stdout = await process.StandardOutput.ReadToEndAsync();
+        string stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode, stdout + stderr);
+    }
+}

--- a/tests/Fluidify.Tests.Functional/CompileTests.cs
+++ b/tests/Fluidify.Tests.Functional/CompileTests.cs
@@ -35,6 +35,9 @@ public class CompileTests
             $"Fluidify build failed:\n{buildResult.Output}");
     }
 
+    private static readonly string CompileFalseAppDir = Path.Combine(
+        SolutionRoot, "tests", "Fluidify.Tests.Functional", "Fixtures", "CompileFalseApp");
+
     [Test]
     public async Task GeneratedCsFile_IsCompiledSuccessfully()
     {
@@ -49,6 +52,24 @@ public class CompileTests
 
         Assert.That(result.ExitCode, Is.EqualTo(0),
             $"CompileApp build failed — generated .cs file was not included in compilation:\n{result.Output}");
+    }
+
+    [Test]
+    public async Task GeneratedCsFile_CompileFalse_IsExcludedFromCompilation()
+    {
+        string generatedFile = Path.Combine(CompileFalseAppDir, "Models", "Greeter.cs");
+
+        // Delete generated file to simulate a clean build
+        if (File.Exists(generatedFile))
+            File.Delete(generatedFile);
+
+        string project = Path.Combine(CompileFalseAppDir, "CompileFalseApp.csproj");
+        (int ExitCode, string Output) result = await RunDotnet($"build \"{project}\" --force");
+
+        Assert.That(result.ExitCode, Is.Not.EqualTo(0),
+            $"Build should have failed — Compile=\"false\" should exclude the generated .cs from compilation:\n{result.Output}");
+        Assert.That(result.Output, Does.Contain("CS0246").Or.Contains("CS0103"),
+            "Expected a missing type/namespace compiler error");
     }
 
     private static async Task<(int ExitCode, string Output)> RunDotnet(string arguments)

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/CompileApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/CompileApp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fluidify" Version="0.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Fluidify Include="Models/Greeter.cs.fluid" Greeting="HELLO" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/CompileApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/CompileApp.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluidify" Version="0.1.0" />
+    <!-- Version must match src/Fluidify/Fluidify.csproj; resolved from the local artifacts feed, not nuget.org -->
+    <PackageReference Include="Fluidify" Version="0.0.0-local" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs
@@ -1,0 +1,6 @@
+namespace CompileApp.Models;
+
+public static class Greeter
+{
+    public static string Message => "HELLO, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs.fluid
@@ -1,0 +1,6 @@
+namespace CompileApp.Models;
+
+public static class Greeter
+{
+    public static string Message => "{{ Greeting }}, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Program.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Program.cs
@@ -1,0 +1,3 @@
+using CompileApp.Models;
+
+Console.WriteLine(Greeter.Message);

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/nuget.config
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Local" value="../../../../artifacts/pkg" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/CompileFalseApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/CompileFalseApp.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Fluidify Include="Models/Greeter.cs.fluid" Greeting="HELLO" />
+    <Fluidify Include="Models/Greeter.cs.fluid" Greeting="HELLO" Compile="false" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/CompileFalseApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/CompileFalseApp.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluidify" Version="0.1.0" />
+    <!-- Version must match src/Fluidify/Fluidify.csproj; resolved from the local artifacts feed, not nuget.org -->
+    <PackageReference Include="Fluidify" Version="0.0.0-local" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs
@@ -1,0 +1,6 @@
+namespace CompileFalseApp.Models;
+
+public static class Greeter
+{
+    public static string Message => "HELLO, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs.fluid
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs.fluid
@@ -1,0 +1,6 @@
+namespace CompileFalseApp.Models;
+
+public static class Greeter
+{
+    public static string Message => "{{ Greeting }}, World!";
+}

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Program.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Program.cs
@@ -1,0 +1,3 @@
+using CompileFalseApp.Models;
+
+Console.WriteLine(Greeter.Message);

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/nuget.config
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Local" value="../../../../artifacts/pkg" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/SampleApp.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluidify" Version="0.1.0" />
+    <!-- Version must match src/Fluidify/Fluidify.csproj; resolved from the local artifacts feed, not nuget.org -->
+    <PackageReference Include="Fluidify" Version="0.0.0-local" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Generated `.cs` files are now automatically added to the `<Compile>` item group — no manual setup needed
- Opt out with `Compile="false"` for `.cs` templates that shouldn't be compiled
- Explicit `Compile="true"` still works for non-`.cs` extensions
- `Compile` metadata is excluded from template variables (like `Destination`)
- README updated with new examples and documentation

## Test plan

- [x] `GeneratedCsFile_IsCompiledSuccessfully` — `.cs` output auto-included, build succeeds
- [x] `GeneratedCsFile_CompileFalse_IsExcludedFromCompilation` — `Compile="false"` opts out, build fails as expected
- [x] Existing `GenerationTests` still pass (5 tests total)

Closes #6