### PR TITLE
Gitignore generated template outputs in test fixtures

### DIFF
--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/.gitignore
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/.gitignore
@@ -1,0 +1,2 @@
+# Generated template outputs (created during test builds)
+Models/Greeter.cs

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileApp/Models/Greeter.cs
@@ -1,6 +1,0 @@
-namespace CompileApp.Models;
-
-public static class Greeter
-{
-    public static string Message => "HELLO, World!";
-}

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/.gitignore
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/.gitignore
@@ -1,0 +1,2 @@
+# Generated template outputs (created during test builds)
+Models/Greeter.cs

--- a/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs
+++ b/tests/Fluidify.Tests.Functional/Fixtures/CompileFalseApp/Models/Greeter.cs
@@ -1,6 +1,0 @@
-namespace CompileFalseApp.Models;
-
-public static class Greeter
-{
-    public static string Message => "HELLO, World!";
-}

--- a/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/.gitignore
+++ b/tests/Fluidify.Tests.Functional/Fixtures/SampleApp/.gitignore
@@ -1,0 +1,4 @@
+# Generated template outputs (created during test builds)
+Models/Greeting.cs
+Config/appsettings.json
+Output/


### PR DESCRIPTION
## Summary

- Add `.gitignore` files to each test fixture app (SampleApp, CompileApp, CompileFalseApp) to ignore generated template outputs
- Remove `Greeter.cs` from git tracking in CompileApp and CompileFalseApp (these are regenerated on every test run)

## Test plan

- [x] `git status` is clean after running tests