### PR TITLE
Fix duplicate Compile entries causing CS2002 warnings

### DIFF
--- a/src/Fluidify/build/Fluidify.targets
+++ b/src/Fluidify/build/Fluidify.targets
@@ -7,13 +7,13 @@
           Condition="'@(Fluidify)' != ''">
     <ItemGroup>
       <Fluidify Condition="'%(Fluidify.Destination)' == ''">
-        <OutputPath>%(RootDir)%(Directory)%(Filename)</OutputPath>
+        <OutputPath>%(RelativeDir)%(Filename)</OutputPath>
       </Fluidify>
       <Fluidify Condition="'%(Fluidify.Destination)' != '' and $([System.IO.Path]::IsPathRooted('%(Fluidify.Destination)'))">
         <OutputPath>%(Fluidify.Destination)</OutputPath>
       </Fluidify>
       <Fluidify Condition="'%(Fluidify.Destination)' != '' and !$([System.IO.Path]::IsPathRooted('%(Fluidify.Destination)'))">
-        <OutputPath>$(MSBuildProjectDirectory)\%(Fluidify.Destination)</OutputPath>
+        <OutputPath>%(Fluidify.Destination)</OutputPath>
       </Fluidify>
     </ItemGroup>
   </Target>

--- a/tests/Fluidify.Tests.Functional/CompileTests.cs
+++ b/tests/Fluidify.Tests.Functional/CompileTests.cs
@@ -72,6 +72,24 @@ public class CompileTests
             "Expected a missing type/namespace compiler error");
     }
 
+    [Test]
+    public async Task RebuildWithExistingOutput_NoDuplicateCompileWarning()
+    {
+        string compileAppProject = Path.Combine(CompileAppDir, "CompileApp.csproj");
+
+        // First build: generates the .cs file on disk
+        (int ExitCode, string Output) firstBuild = await RunDotnet($"build \"{compileAppProject}\" --force");
+        Assert.That(firstBuild.ExitCode, Is.EqualTo(0),
+            $"First build failed:\n{firstBuild.Output}");
+
+        // Second build: SDK glob picks up the file AND Fluidify adds it — should not duplicate
+        (int ExitCode, string Output) secondBuild = await RunDotnet($"build \"{compileAppProject}\" --force");
+        Assert.That(secondBuild.ExitCode, Is.EqualTo(0),
+            $"Second build failed:\n{secondBuild.Output}");
+        Assert.That(secondBuild.Output, Does.Not.Contain("CS2002"),
+            $"Duplicate compile warning detected on rebuild:\n{secondBuild.Output}");
+    }
+
     private static async Task<(int ExitCode, string Output)> RunDotnet(string arguments)
     {
         ProcessStartInfo psi = new ProcessStartInfo("dotnet", arguments)


### PR DESCRIPTION
Closes #10

## Summary
- Use relative paths in `ComputeFluidifyOutputs` so `Compile Remove` matches SDK glob entries — `%(RelativeDir)%(Filename)` instead of `%(RootDir)%(Directory)%(Filename)`, and `%(Fluidify.Destination)` instead of `$(MSBuildProjectDirectory)\%(Fluidify.Destination)`
- Add `RebuildWithExistingOutput_NoDuplicateCompileWarning` test that builds twice and asserts no CS2002 warning

## Test plan
- [x] New test fails before fix, passes after
- [x] All 6 functional tests pass