### PR TITLE
Document automatic Compile deduplication in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Fluidify works with any text format — C#, JSON, HTML, YAML, or anything else. 
 
 ### Compilation
 
-Generated `.cs` files are automatically included in compilation. Fluidify handles deduplication, so you don't need to add `<Compile Remove>` for generated files — there will be no CS2002 "specified multiple times" warnings even on rebuild.
+Generated `.cs` files are automatically included in compilation. Fluidify handles deduplication, so you don't need to add `<Compile Remove>` for generated files.
 
 To opt out of compilation, set `Compile="false"`:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Fluidify works with any text format — C#, JSON, HTML, YAML, or anything else. 
 
 ### Compilation
 
-Generated `.cs` files are automatically included in compilation. To opt out, set `Compile="false"`:
+Generated `.cs` files are automatically included in compilation. Fluidify handles deduplication, so you don't need to add `<Compile Remove>` for generated files — there will be no CS2002 "specified multiple times" warnings even on rebuild.
+
+To opt out of compilation, set `Compile="false"`:
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds a note to the Compilation section of the README explaining that Fluidify handles Compile deduplication automatically, so users don't need to add `<Compile Remove>` for generated files.

Closes #12